### PR TITLE
new commands: `user {add,show,ls}`, `nb set-defaults`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ scverse
 #   invite  Create/List invitations to a TileDB-Cloud namespace.
 #   nb      Notebook-CRUD TileDB-Cloud commands for the...
 #   org     Manage a TileDB-Cloud organization / namespace.
+#   user    Manage a scverse TileDB-Cloud user.
 ```
 
 #### Auth
@@ -42,8 +43,6 @@ scverse org
 #
 # Commands:
 #   show (info)  Print a TileDB-Cloud organization.
-#   user         Show a TileDB-Cloud user.
-#   users        List users in a TileDB-Cloud organization.
 ```
 
 <!-- `bmdfff -- scverse org show --help` -->
@@ -56,46 +55,10 @@ Usage: scverse org show [OPTIONS]
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
-  --help                       Show this message and exit.
-```
-</details>
-
-<!-- `bmdfff -- scverse org users --help` -->
-<details><summary><code>scverse org users --help</code></summary>
-
-```
-Usage: scverse org users [OPTIONS]
-
-  List users in a TileDB-Cloud organization.
-
-Options:
-  -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
-                               $TILEDB_REST_TOKEN takes precedence, if set.
-  -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
-  -C, --compact                Print compact JSON
-  --help                       Show this message and exit.
-```
-</details>
-
-<!-- `bmdfff -- scverse org user --help` -->
-<details><summary><code>scverse org user --help</code></summary>
-
-```
-Usage: scverse org user [OPTIONS] [USERNAME]
-
-  Show a TileDB-Cloud user.
-
-Options:
-  -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
-                               $TILEDB_REST_TOKEN takes precedence, if set.
-  -C, --compact                Print compact JSON
+                               "scverse-ml-workshop-2024"
   --help                       Show this message and exit.
 ```
 </details>
@@ -112,7 +75,7 @@ scverse invite
 #   --help  Show this message and exit.
 #
 # Commands:
-#   do (send)  Invite a user to a TileDB-Cloud namespace
+#   do (send)  Invite a user to a TileDB-Cloud namespace.
 #   ls (list)  List a TileDB-Cloud namespace's outstanding invitations
 #   rm         Revoke one or more outstanding invitations to a TileDB-Cloud
 #              namespace
@@ -124,18 +87,18 @@ scverse invite
 ```
 Usage: scverse invite send [OPTIONS] [EMAILS]...
 
-  Invite a user to a TileDB-Cloud namespace
+  Invite a user to a TileDB-Cloud namespace.
 
 Options:
   -t, --cloud-token-path TEXT     Path to file containing TileDB-Cloud auth
-                                  token; default: .tiledb-cloud-token.
+                                  token; default: ".tiledb-cloud-token".
                                   $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT            TileDB-Cloud namespace to work in; default:
-                                  scverse-ml-workshop-2024
-  -r, --role [owner|admin|read_write|read_only]
+                                  "scverse-ml-workshop-2024"
+  -R, --role [owner|admin|read_write|read_only]
                                   Role to invite new user as (options:
                                   ['owner', 'admin', 'read_write',
-                                  'read_only']; default: read_write)
+                                  'read_only']; default: "read_write")
   --help                          Show this message and exit.
 ```
 </details>
@@ -150,10 +113,10 @@ Usage: scverse invite list [OPTIONS]
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
+                               "scverse-ml-workshop-2024"
   -C, --compact                Print compact JSON
   --help                       Show this message and exit.
 ```
@@ -169,10 +132,10 @@ Usage: scverse invite rm [OPTIONS] [EMAILS]...
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
+                               "scverse-ml-workshop-2024"
   -n, --dry-run                Print commands that would be run, but don't run
                                them
   -S, --no-strict              Raise and exit if any email is not found,
@@ -194,14 +157,16 @@ scverse nb
 #   --help  Show this message and exit.
 #
 # Commands:
-#   cp (copy)       Create one or more copies of a "template" notebook, with
-#                   names...
-#   get (download)  Download a TileDB-Cloud notebook; [DST] of "-" prints to
-#                   stdout.
-#   ls (list)       List TileDB-Cloud notebooks.
-#   md (metadata)   Show a TileDB-Cloud notebook's metadata.
-#   put (upload)    Upload a notebook to TileDB-Cloud.
-#   rm (delete)     Delete a notebook from TileDB-Cloud, by namespace and name.
+#   cp (copy)          Create one or more copies of a "template" notebook, with
+#                      names...
+#   get (download)     Download a TileDB-Cloud notebook; [DST] of "-" prints to
+#                      stdout.
+#   ls (list)          List TileDB-Cloud notebooks.
+#   md (metadata)      Show a TileDB-Cloud notebook's metadata.
+#   put (upload)       Upload a notebook to TileDB-Cloud.
+#   rm (delete)        Delete a notebook from TileDB-Cloud, by namespace and
+#                      name.
+#   sd (set-defaults)  Set default image, region, and size for a notebook.
 ```
 
 <!-- `bmdfff -- scverse nb ls --help` -->
@@ -214,10 +179,10 @@ Usage: scverse nb ls [OPTIONS]
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
+                               "scverse-ml-workshop-2024"
   --help                       Show this message and exit.
 ```
 </details>
@@ -233,14 +198,16 @@ Usage: scverse nb cp [OPTIONS] [EMAILS]...
 
 Options:
   -t, --cloud-token-path TEXT   Path to file containing TileDB-Cloud auth
-                                token; default: .tiledb-cloud-token.
+                                token; default: ".tiledb-cloud-token".
                                 $TILEDB_REST_TOKEN takes precedence, if set.
+  -c, --credential-name TEXT    Storage credential name; default: "scverse-ml-
+                                workshop-2024"
   -N, --namespace TEXT          TileDB-Cloud namespace to work in; default:
-                                scverse-ml-workshop-2024
+                                "scverse-ml-workshop-2024"
   -n, --dry-run                 Print commands that would be run, but don't
                                 run them
   -s, --src-notebook-name TEXT  "Read-only" notebook name, to be copied and
-                                renamed for each user.
+                                renamed for each user (default: "template").
   --help                        Show this message and exit.
 ```
 </details>
@@ -255,10 +222,10 @@ Usage: scverse nb get [OPTIONS] NB_NAME [DST]
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
+                               "scverse-ml-workshop-2024"
   --help                       Show this message and exit.
 ```
 </details>
@@ -273,11 +240,32 @@ Usage: scverse nb md [OPTIONS] NB_NAME
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
+                               "scverse-ml-workshop-2024"
   -C, --compact                Print compact JSON
+  --help                       Show this message and exit.
+```
+</details>
+
+<!-- `bmdfff -- scverse nb sd` -->
+<details><summary><code>scverse nb sd</code></summary>
+
+```
+Usage: scverse nb sd [OPTIONS] NB_NAME
+
+  Set default image, region, and size for a notebook.
+
+Options:
+  -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
+                               token; default: ".tiledb-cloud-token".
+                               $TILEDB_REST_TOKEN takes precedence, if set.
+  -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
+                               "scverse-ml-workshop-2024"
+  -i, --image TEXT             Default image
+  -r, --region TEXT            Default region
+  -z, --size TEXT              Default server size
   --help                       Show this message and exit.
 ```
 </details>
@@ -292,14 +280,14 @@ Usage: scverse nb put [OPTIONS] SRC [DST_NAME]
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
-  -c, --credential-name TEXT   Storage credential name; default: scverse-ml-
-                               workshop-2024
+  -c, --credential-name TEXT   Storage credential name; default: "scverse-ml-
+                               workshop-2024"
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
-  -S, --storage-path TEXT      Storage path; default: s3://tiledb-conferences-
-                               us-west-2/scverse-ml-workshop-2024
+                               "scverse-ml-workshop-2024"
+  -S, --storage-path TEXT      Storage path; default: "s3://tiledb-
+                               conferences-us-west-2/scverse-ml-workshop-2024"
   -d, --delete                 If True, delete the notebook after uploading
                                (e.g. for testing uploading/deleting)
   --help                       Show this message and exit.
@@ -316,15 +304,92 @@ Usage: scverse nb rm [OPTIONS] [NB_NAMES]...
 
 Options:
   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
-                               token; default: .tiledb-cloud-token.
+                               token; default: ".tiledb-cloud-token".
                                $TILEDB_REST_TOKEN takes precedence, if set.
   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
-                               scverse-ml-workshop-2024
+                               "scverse-ml-workshop-2024"
   -n, --dry-run                Print commands that would be run, but don't run
                                them
   --help                       Show this message and exit.
 ```
 </details>
+
+### `scverse user`: Add/Show/List organization users
+<!-- `bmdf scverse user` -->
+```bash
+scverse user
+# Usage: scverse user [OPTIONS] COMMAND [ARGS]...
+#
+#   Manage a scverse TileDB-Cloud user.
+#
+# Options:
+#   --help  Show this message and exit.
+#
+# Commands:
+#   add   Add and initialize (notebook copy + defaults) one or more users...
+#   ls    List users in a TileDB-Cloud organization.
+#   show  Show a TileDB-Cloud user.
+```
+
+<!-- `bmdf -- scverse user show --help` -->
+```bash
+scverse user show --help
+# Usage: scverse user show [OPTIONS] [USERNAME]
+#
+#   Show a TileDB-Cloud user.
+#
+# Options:
+#   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
+#                                token; default: ".tiledb-cloud-token".
+#                                $TILEDB_REST_TOKEN takes precedence, if set.
+#   -C, --compact                Print compact JSON
+#   --help                       Show this message and exit.
+```
+
+<!-- `bmdf -- scverse user ls --help` -->
+```bash
+scverse user ls --help
+# Usage: scverse user ls [OPTIONS]
+#
+#   List users in a TileDB-Cloud organization.
+#
+# Options:
+#   -t, --cloud-token-path TEXT  Path to file containing TileDB-Cloud auth
+#                                token; default: ".tiledb-cloud-token".
+#                                $TILEDB_REST_TOKEN takes precedence, if set.
+#   -N, --namespace TEXT         TileDB-Cloud namespace to work in; default:
+#                                "scverse-ml-workshop-2024"
+#   -C, --compact                Print compact JSON
+#   --help                       Show this message and exit.
+```
+
+<!-- `bmdf scverse user add` -->
+```bash
+scverse user add
+# Usage: scverse user add [OPTIONS] [EMAILS]...
+#
+#   Add and initialize (notebook copy + defaults) one or more users to a TileDB-
+#   Cloud namespace.
+#
+# Options:
+#   -t, --cloud-token-path TEXT     Path to file containing TileDB-Cloud auth
+#                                   token; default: ".tiledb-cloud-token".
+#                                   $TILEDB_REST_TOKEN takes precedence, if set.
+#   -c, --credential-name TEXT      Storage credential name; default: "scverse-
+#                                   ml-workshop-2024"
+#   -N, --namespace TEXT            TileDB-Cloud namespace to work in; default:
+#                                   "scverse-ml-workshop-2024"
+#   -R, --role [owner|admin|read_write|read_only]
+#                                   Role to invite new user as (options:
+#                                   ['owner', 'admin', 'read_write',
+#                                   'read_only']; default: "read_write")
+#   -s, --src-notebook-name TEXT    "Read-only" notebook name, to be copied and
+#                                   renamed for each user (default: "template").
+#   -i, --image TEXT                Default image
+#   -r, --region TEXT               Default region
+#   -z, --size TEXT                 Default server size
+#   --help                          Show this message and exit.
+```
 
 ## Example notebooks/tutorials
 See [examples/](examples/):

--- a/scverse/cli/base.py
+++ b/scverse/cli/base.py
@@ -1,5 +1,6 @@
-from click import group, option
+from click import group, option, Choice
 from tiledb.cloud import client
+from tiledb.cloud.rest_api import OrganizationRoles
 
 
 @group
@@ -9,19 +10,30 @@ def cli():
 
 
 NAMESPACE = 'scverse-ml-workshop-2024'
+PARTICIPANTS_NB_DIR = "participants"
+DEFAULT_IMAGE = 'genomics'  # TODO
+DEFAULT_REGION = 'us-west-2'
 DEFAULT_STORAGE_PATH = 's3://tiledb-conferences-us-west-2/scverse-ml-workshop-2024'
 DEFAULT_CREDENTIAL_NAME = 'scverse-ml-workshop-2024'
 DEFAULT_CLOUD_TOKEN_PATH = '.tiledb-cloud-token'
 TILEDB_REST_TOKEN_VAR = 'TILEDB_REST_TOKEN'
 TEMPLATE_NAME = 'template'  # "Read-only" notebook, to be copied and renamed for each user.
+DEFAULT_SERVER_SIZE = 'large'  # TODO
 
+READ_WRITE = OrganizationRoles.READ_WRITE
+ROLES = OrganizationRoles.allowable_values
 
-credential_opt = option('-c', '--credential-name', default=DEFAULT_CREDENTIAL_NAME, help=f'Storage credential name; default: {DEFAULT_CREDENTIAL_NAME}')
+credential_opt = option('-c', '--credential-name', default=DEFAULT_CREDENTIAL_NAME, help=f'Storage credential name; default: "{DEFAULT_CREDENTIAL_NAME}"')
 compact_opt = option('-C', '--compact', is_flag=True, help="Print compact JSON")
+image_opt = option('-i', '--image', default=DEFAULT_IMAGE, help='Default image')
 dry_run_opt = option('-n', '--dry-run', is_flag=True, help="Print commands that would be run, but don't run them")
-namespace_opt = option('-N', '--namespace', default=NAMESPACE, help=f'TileDB-Cloud namespace to work in; default: {NAMESPACE}')
-cloud_token_opt = option('-t', '--cloud-token-path', default=DEFAULT_CLOUD_TOKEN_PATH, help=f'Path to file containing TileDB-Cloud auth token; default: {DEFAULT_CLOUD_TOKEN_PATH}. ${TILEDB_REST_TOKEN_VAR} takes precedence, if set.')
-storage_path_opt = option('-S', '--storage-path', default=DEFAULT_STORAGE_PATH, help=f'Storage path; default: {DEFAULT_STORAGE_PATH}')
+namespace_opt = option('-N', '--namespace', default=NAMESPACE, help=f'TileDB-Cloud namespace to work in; default: "{NAMESPACE}"')
+cloud_token_opt = option('-t', '--cloud-token-path', default=DEFAULT_CLOUD_TOKEN_PATH, help=f'Path to file containing TileDB-Cloud auth token; default: "{DEFAULT_CLOUD_TOKEN_PATH}". ${TILEDB_REST_TOKEN_VAR} takes precedence, if set.')
+storage_path_opt = option('-S', '--storage-path', default=DEFAULT_STORAGE_PATH, help=f'Storage path; default: "{DEFAULT_STORAGE_PATH}"')
+region_opt = option('-r', '--region', default=DEFAULT_REGION, help='Default region')
+role_opt = option('-R', '--role', type=Choice(ROLES), default=READ_WRITE, help=f'Role to invite new user as (options: {ROLES}; default: "{READ_WRITE}")')
+src_nb_opt = option('-s', '--src-notebook-name', default=TEMPLATE_NAME, help=f'"Read-only" notebook name, to be copied and renamed for each user (default: "{TEMPLATE_NAME}").')
+size_opt = option('-z', '--size', default=DEFAULT_SERVER_SIZE, help='Default server size')
 
 
 def get_arrays(namespace: str):

--- a/scverse/cli/invite/__init__.py
+++ b/scverse/cli/invite/__init__.py
@@ -1,33 +1,18 @@
-import logging
 import json
-import os
-import re
-import sys
-from attrs import define, field
-from importlib.metadata import version
-
-from click import argument, Choice, option
-from functools import partial
+from click import argument, option
+from functools import partial, wraps
 from tiledb import cloud
 from tiledb.cloud import invites  # required for `cloud.invites` to resolve
-from tiledb.cloud.rest_api import InvitationApi, InvitationOrganizationJoinEmail, ApiException, NotebookApi
-from tiledb.cloud.rest_api.models import OrganizationRoles, NotebookCopy
-from utz import err
-
 from tiledb.cloud.client import client
-
+from tiledb.cloud.rest_api import InvitationApi, InvitationOrganizationJoinEmail, ApiException
 from tiledb.cloud.tiledb_cloud_error import maybe_wrap
-from ...util.json import DateTimeEncoder
-
-READ_WRITE = OrganizationRoles.READ_WRITE
-ROLES = OrganizationRoles.allowable_values
-
-from typing import cast, Any, Optional, Sequence, List
+from typing import cast, Any, Optional, Sequence
+from utz import err, decos
 
 from ..aliased_group import AliasedGroup
-from ..base import cli, compact_opt, dry_run_opt
+from ..base import cli, compact_opt, dry_run_opt, role_opt
 from ..command import command
-
+from ...util.json import DateTimeEncoder
 
 
 @cli.group(cls=AliasedGroup)
@@ -47,11 +32,14 @@ def get_invites(namespace: str, emails: Optional[list[str]] = None) -> list[dict
     return [ i.to_dict() for i in invites ]
 
 
-def get_invites_by_email(namespace: str) -> dict[str, dict]:
-    return {
-        invite['email']: invite
-        for invite in get_invites(namespace)
-    }
+def get_invites_by_email(namespace: str) -> dict[str, list[dict]]:
+    invites = {}
+    for invite in get_invites(namespace):
+        email = invite['email']
+        if email not in invites:
+            invites[email] = []
+        invites[email].append(invite)
+    return invites
 
 
 @cmd('list', no_args_is_help=False)
@@ -91,107 +79,19 @@ def invite_to_organization(
         return invitation_api.join_organization(organization, email_invite)
     except ApiException as exc:
         raise maybe_wrap(exc)
-    
-
-@define
-class MakeNB:
-
-    namespace: str = "scverse-ml-workshop-2024"
-    """Namespace to deposit notebooks."""
-    acn: str = "scverse-ml-workshop-2024"
-    """Access credential name."""
-    logger: logging.Logger = field()
-    """logger for notebook creation."""
-
-    @logger.default
-    def _get_logger(self) -> logging.Logger:
-        return self._inst_logger()
-    
-    s3_particpant_uri: str = "s3://tiledb-conferences-us-west-2/scverse-ml-workshop-2024/participants"
-    """S3 URI to store copied notebooks."""
-    template_nb: str = "template"
-    """Name of workshop template notebook."""
-
-    def _inst_logger(self, level: str = logging.INFO) -> logging.Logger:
-
-        logger = logging.getLogger(__name__)
-        logger.addHandler(logging.StreamHandler(sys.stdout))
-        # init format
-        lformat = logging.Formatter(
-            fmt="\033[96mscverse-cli\033[0m %(message)s\n",
-            datefmt="%d-%b-%y %H:%M:%S",
-        )
-        # set the format for the logger
-        logger.handlers[0].setFormatter(lformat)
-        logger.setLevel(level)
-
-        logger.debug("\033[93m%s\033[0m logger initialized." % version("scverse-workshop"))
-
-        return logger
 
 
-    def rename(self, email: str) -> str:
-        """Consumes an email and creates a notebook.
-        
-        input: spencer.seale@tiledb.com
-        output: spencerseale--tiledb-com
-        """
-
-        username, domain = email.split("@")
-        modified_username = re.sub("\.", '', username)
-        modified_domain = re.sub("\.", '-', domain)
-
-        notebook_name = modified_username + "--" + modified_domain
-
-        self.logger.info(f"\033[93m{notebook_name}\033[0m will be made for user {email}")
-
-        return notebook_name
-        
-
-    def name_nbs(self, emails: Sequence[str]) -> List[str]:
-        """Orchestrator for notebook renaming."""
-
-        nb_to_make = []
-        for user in emails:
-            nb_to_make.append(self.rename(user))
-
-        return nb_to_make
-
-
-    def make_user_nbs(self, emails: Sequence[str]):
-        """Runner to name and copy notebooks."""
-        
-        to_make = self.name_nbs(emails)
-        notebook_api = client.build(NotebookApi)
-
-        for new_nb in to_make:
-            self.logger.info(f"Creating {new_nb}")
-            nc = NotebookCopy(
-                output_uri=os.path.join(self.s3_particpant_uri, new_nb),
-                name=new_nb,
-                namespace=self.namespace,
-            )
-
-            notebook_api.handle_copy_notebook(
-                namespace=self.namespace,
-                array="template",
-                notebook_copy=nc,
-                x_tiledb_cloud_access_credentials_name=self.acn,
-            )
-            self.logger.info(f"{new_nb} added to namespace!")
-
-        self.logger.info("All notebooks created \033[93m:D\033[0m")
-
-
-@cmd('send')
-@option('-r', '--role', type=Choice(ROLES), default=READ_WRITE, help=f"Role to invite new user as (options: {ROLES}; default: {READ_WRITE})")
-@argument('emails', nargs=-1)
-def do(namespace, credential_name, role, emails):
-    """Invite a user to a TileDB-Cloud namespace and create their notebook copy."""
+def do(namespace, role, emails):
+    """Invite a user to a TileDB-Cloud namespace."""
     invite_to_organization(namespace, recipients=emails, role=role)
 
-    maker = MakeNB(namespace=namespace, acn=credential_name)
-    maker.make_user_nbs(emails=emails)
+
+_do = decos(
+    cmd('send'),
+    role_opt,
+    argument('emails', nargs=-1),
+    wraps(do),
+)(do)
 
 
 @cmd()
@@ -200,19 +100,20 @@ def do(namespace, credential_name, role, emails):
 @argument('emails', nargs=-1)
 def rm(namespace, dry_run, no_strict, emails):
     """Revoke one or more outstanding invitations to a TileDB-Cloud namespace"""
-    invites = get_invites_by_email(namespace)
+    invites_by_email = get_invites_by_email(namespace)
     if not no_strict:
         for email in emails:
-            if email not in invites:
+            if email not in invites_by_email:
                 raise RuntimeError(f"No invitation found for {email}")
     for email in emails:
-        if no_strict and email not in invites:
+        if no_strict and email not in invites_by_email:
             err(f"No invitation found for {email}")
             continue
-        invite = invites[email]
-        id = invite['id']
-        if dry_run:
-            err(f"Would cancel invite {id} to {email}")
-        else:
-            cloud.invites.cancel_invite_to_organization(namespace, invitation_id=id)
-            err(f"Revoked invite {id} to {email}")
+        invites = invites_by_email[email]
+        for invite in invites:
+            id = invite['id']
+            if dry_run:
+                err(f"Would cancel invite {id} to {email}")
+            else:
+                cloud.invites.cancel_invite_to_organization(namespace, invitation_id=id)
+                err(f"Revoked invite {id} to {email}")

--- a/scverse/cli/invite/__init__.py
+++ b/scverse/cli/invite/__init__.py
@@ -1,11 +1,17 @@
+import logging
 import json
+import os
+import re
+import sys
+from attrs import define, field
+from importlib.metadata import version
 
 from click import argument, Choice, option
 from functools import partial
 from tiledb import cloud
 from tiledb.cloud import invites  # required for `cloud.invites` to resolve
-from tiledb.cloud.rest_api import InvitationApi, InvitationOrganizationJoinEmail, ApiException
-from tiledb.cloud.rest_api.models import OrganizationRoles
+from tiledb.cloud.rest_api import InvitationApi, InvitationOrganizationJoinEmail, ApiException, NotebookApi
+from tiledb.cloud.rest_api.models import OrganizationRoles, NotebookCopy
 from utz import err
 
 from tiledb.cloud.client import client
@@ -16,12 +22,12 @@ from ...util.json import DateTimeEncoder
 READ_WRITE = OrganizationRoles.READ_WRITE
 ROLES = OrganizationRoles.allowable_values
 
-
-from typing import cast, Any, Optional, Sequence
+from typing import cast, Any, Optional, Sequence, List
 
 from ..aliased_group import AliasedGroup
 from ..base import cli, compact_opt, dry_run_opt
 from ..command import command
+
 
 
 @cli.group(cls=AliasedGroup)
@@ -84,14 +90,107 @@ def invite_to_organization(
         return invitation_api.join_organization(organization, email_invite)
     except ApiException as exc:
         raise maybe_wrap(exc)
+    
+
+@define
+class MakeNB:
+
+    namespace: str = "scverse-ml-workshop-2024"
+    """Namespace to deposit notebooks."""
+    acn: str = "scverse-ml-workshop-2024"
+    """Access credential name."""
+    logger: logging.Logger = field()
+    """logger for notebook creation."""
+
+    @logger.default
+    def _get_logger(self) -> logging.Logger:
+        return self._inst_logger()
+    
+    s3_particpant_uri: str = "s3://tiledb-conferences-us-west-2/scverse-ml-workshop-2024/participants"
+    """S3 URI to store copied notebooks."""
+    template_nb: str = "template"
+    """Name of workshop template notebook."""
+
+    def _inst_logger(self, level: str = logging.INFO) -> logging.Logger:
+
+        logger = logging.getLogger(__name__)
+        logger.addHandler(logging.StreamHandler(sys.stdout))
+        # init format
+        lformat = logging.Formatter(
+            fmt="\033[96mscverse-cli\033[0m %(message)s\n",
+            datefmt="%d-%b-%y %H:%M:%S",
+        )
+        # set the format for the logger
+        logger.handlers[0].setFormatter(lformat)
+        logger.setLevel(level)
+
+        logger.debug("\033[93m%s\033[0m logger initialized." % version("scverse-workshop"))
+
+        return logger
+
+
+    def rename(self, email: str) -> str:
+        """Consumes an email and creates a notebook.
+        
+        input: spencer.seale@tiledb.com
+        output: spencerseale--tiledb-com
+        """
+
+        username, domain = email.split("@")
+        modified_username = re.sub("\.", '', username)
+        modified_domain = re.sub("\.", '-', domain)
+
+        notebook_name = modified_username + "--" + modified_domain
+
+        self.logger.info(f"\033[93m{notebook_name}\033[0m will be made for user {email}")
+
+        return notebook_name
+        
+
+    def name_nbs(self, emails: Sequence[str]) -> List[str]:
+        """Orchestrator for notebook renaming."""
+
+        nb_to_make = []
+        for user in emails:
+            nb_to_make.append(self.rename(user))
+
+        return nb_to_make
+
+
+    def make_user_nbs(self, emails: Sequence[str]):
+        """Runner to name and copy notebooks."""
+        
+        to_make = self.name_nbs(emails)
+        notebook_api = client.build(NotebookApi)
+
+        for new_nb in to_make:
+            self.logger.info(f"Creating {new_nb}")
+            nc = NotebookCopy(
+                output_uri=os.path.join(self.s3_particpant_uri, new_nb),
+                name=new_nb,
+                namespace=self.namespace,
+            )
+
+            notebook_api.handle_copy_notebook(
+                namespace=self.namespace,
+                array="template",
+                notebook_copy=nc,
+                x_tiledb_cloud_access_credentials_name=self.acn,
+            )
+            self.logger.info(f"{new_nb} added to namespace!")
+
+        self.logger.info("All notebooks created \033[93m:D\033[0m")
 
 
 @cmd('send')
 @option('-r', '--role', type=Choice(ROLES), default=READ_WRITE, help=f"Role to invite new user as (options: {ROLES}; default: {READ_WRITE})")
 @argument('emails', nargs=-1)
-def do(namespace, role, emails):
-    """Invite a user to a TileDB-Cloud namespace"""
+def do(namespace, credential_name, role, emails):
+    """Invite a user to a TileDB-Cloud namespace and create their notebook copy."""
     invite_to_organization(namespace, recipients=emails, role=role)
+
+    maker = MakeNB(namespace=namespace, acn=credential_name)
+    maker.make_user_nbs(emails=emails)
 
 
 @cmd()

--- a/scverse/cli/main.py
+++ b/scverse/cli/main.py
@@ -1,7 +1,7 @@
 from .base import cli as main
-from . import nb
-from . import org
-from . import invite
+
+# Register subcommands
+from . import invite, nb, org, user
 
 
 if __name__ == '__main__':

--- a/scverse/cli/nb/__init__.py
+++ b/scverse/cli/nb/__init__.py
@@ -17,4 +17,4 @@ cmd = partial(command, nb)
 
 
 # Register `nb` subcommands
-from . import cp, get, ls, md, put, rm
+from . import cp, get, ls, md, put, rm, set_defaults

--- a/scverse/cli/nb/rm.py
+++ b/scverse/cli/nb/rm.py
@@ -18,8 +18,9 @@ def rm(namespace, dry_run, nb_names):
     for arr in arrs1:
         if arr.name in nb_names:
             if dry_run:
-                err(f"Would delete {arr.name}")
+                err(f"Would delete {arr.tiledb_uri}")
             else:
+                err("Deleting", arr.tiledb_uri)
                 cloud.array.delete_array(arr.tiledb_uri)
 
     if not dry_run:

--- a/scverse/cli/nb/set_defaults.py
+++ b/scverse/cli/nb/set_defaults.py
@@ -1,0 +1,34 @@
+from click import argument
+from tiledb.cloud.client import client
+from tiledb.cloud.rest_api.api.array_api import ArrayApi
+from tiledb.cloud.rest_api.models.array_info_update import ArrayInfoUpdate
+from utz import decos
+
+from . import cmd
+from ..base import image_opt, region_opt, size_opt
+
+
+def set_defaults(namespace, image, region, size, nb_name):
+    """Set default image, region, and size for a notebook."""
+    array_api = client.build(ArrayApi)
+
+    array_api.update_array_metadata(
+        namespace=namespace,
+        array=nb_name,
+        array_metadata=ArrayInfoUpdate(
+            file_properties=dict(
+                image=image,
+                region=region,
+                size=size,
+            )
+        )
+    )
+
+
+_set_defaults = decos(
+    cmd('set-defaults', name='sd'),
+    image_opt,
+    region_opt,
+    size_opt,
+    argument('nb-name'),
+)(set_defaults)

--- a/scverse/cli/org/__init__.py
+++ b/scverse/cli/org/__init__.py
@@ -26,26 +26,3 @@ cmd = partial(command, org)
 def show(namespace):
     """Print a TileDB-Cloud organization."""
     print(cloud.organization(namespace))
-
-
-@cmd(no_args_is_help=False)
-@json_output
-def users(namespace):
-    """List users in a TileDB-Cloud organization."""
-    org = cloud.organization(namespace)
-    return [
-        user.to_dict()
-        for user in org.users
-    ]
-
-
-@cmd(no_args_is_help=False)
-@json_output
-@argument('username', required=False)
-def user(username):
-    """Show a TileDB-Cloud user."""
-    if username:
-        user = client.build(UserApi).get_user_with_username(username)
-    else:
-        user = user_profile()
-    return user.to_dict()

--- a/scverse/cli/user/__init__.py
+++ b/scverse/cli/user/__init__.py
@@ -1,0 +1,92 @@
+from click import argument, pass_context
+from functools import partial
+from tiledb import cloud
+from tiledb.cloud.client import client, user_profile
+from tiledb.cloud.rest_api import UserApi
+from typing import cast
+from utz import err
+
+from scverse.cli.aliased_group import AliasedGroup
+from scverse.cli.base import cli, role_opt, src_nb_opt, image_opt, region_opt, size_opt
+from scverse.cli.command import command, json_output
+from scverse.cli import invite
+from scverse.cli.nb.cp import cp as nb_cp
+from scverse.cli.nb.set_defaults import set_defaults as nb_set_defaults
+
+
+@cli.group(cls=AliasedGroup)
+@pass_context
+def user(ctx):
+    """Manage a scverse TileDB-Cloud user."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(show)
+
+
+user = cast(AliasedGroup, user)
+cmd = partial(command, user)
+
+
+@cmd(no_args_is_help=False)
+@json_output
+@argument('username', required=False)
+def show(username):
+    """Show a TileDB-Cloud user."""
+    if username:
+        user = client.build(UserApi).get_user_with_username(username)
+    else:
+        user = user_profile()
+    return user.to_dict()
+
+
+@cmd(no_args_is_help=False)
+@json_output
+def ls(namespace):
+    """List users in a TileDB-Cloud organization."""
+    org = cloud.organization(namespace)
+    return [
+        user.to_dict()
+        for user in org.users
+    ]
+
+
+@cmd()
+@role_opt
+@src_nb_opt
+@image_opt
+@region_opt
+@size_opt
+@argument('emails', nargs=-1)
+def add(
+    namespace,
+    credential_name,
+    role,
+    src_notebook_name,
+    image,
+    region,
+    size,
+    emails,
+):
+    """Add and initialize (notebook copy + defaults) one or more users to a TileDB-Cloud namespace."""
+    for email in emails:
+        err("Inviting", email, "to", namespace, "with role", role)
+        invite.do(
+            namespace=namespace,
+            role=role,
+            emails=(email,),
+        )
+        err("Copying", src_notebook_name, "to", namespace, "for", email)
+        [nb_name] = nb_cp(
+            namespace=namespace,
+            credential_name=credential_name,
+            dry_run=False,
+            src_notebook_name=src_notebook_name,
+            emails=(email,),
+        )
+        err("Setting", email, "defaults")
+        nb_set_defaults(
+            namespace=namespace,
+            image=image,
+            region=region,
+            size=size,
+            nb_name=nb_name,
+        )


### PR DESCRIPTION
Incorporating #2 into `scverse user add`, which:
1. invites user(s)
2. creates namespaced copy of `template` notebook
3. sets default image/region/size for launching notebook

Also added `nb set-defaults` (standalone CLI for step 3 above), and moved `org user{,s}` to `user {show,ls}`.